### PR TITLE
Fix settings import names

### DIFF
--- a/moodsinger/settings.py
+++ b/moodsinger/settings.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
     'drf_yasg',
 
     # Local apps
-    'apps.authounts',                  # Use only the correct app name
+    'apps.acc',                  # Use only the correct app name
     'apps.music',
     'apps.analysis',
     'apps.feature_settings',
@@ -130,7 +130,7 @@ REST_FRAMEWORK = {
 
 # JWT Settings
 SIMPLE_JWT = {
-    'authESS_TOKEN_LIFETIME': timedelta(days=1),
+    'ACCESS_TOKEN_LIFETIME': timedelta(days=1),
     'REFRESH_TOKEN_LIFETIME': timedelta(days=7),
     'ROTATE_REFRESH_TOKENS': True,
     'BLACKLIST_AFTER_ROTATION': True,
@@ -145,7 +145,7 @@ CORS_ALLOWED_ORIGINS = [
 # Celery Configuration
 CELERY_BROKER_URL = config('REDIS_URL', default='redis://localhost:6379/0')
 CELERY_RESULT_BACKEND = config('REDIS_URL', default='redis://localhost:6379/0')
-CELERY_authEPT_CONTENT = ['json']
+CELERY_ACCEPT_CONTENT = ['json']
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_RESULT_SERIALIZER = 'json'
 


### PR DESCRIPTION
## Summary
- fix installed user app name
- correct JWT and Celery typo variables

## Testing
- `python -m py_compile moodsinger/settings.py`
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'apps.auth')*

------
https://chatgpt.com/codex/tasks/task_e_683fb78c5aa4832aa3e78390716226b0