### PR TITLE
Fix routing for accounts and feature settings

### DIFF
--- a/apps/acc/urls.py
+++ b/apps/acc/urls.py
@@ -5,5 +5,4 @@ urlpatterns = [
     path('register/', views.register, name='register'),
     path('login/', views.login, name='login'),
     path('google/', views.google_auth, name='google-auth'),
-    path('api/auth/', include('apps.accounts.urls')), 
 ]

--- a/apps/feature_settings/urls.py
+++ b/apps/feature_settings/urls.py
@@ -3,5 +3,5 @@ from . import views
 
 urlpatterns = [
     path('', views.get_settings, name='get-settings'),
-    path('', views.update_settings, name='update-settings'),
+    path('update/', views.update_settings, name='update-settings'),
 ]


### PR DESCRIPTION
## Summary
- remove bad include of non-existent accounts URLs
- give separate route for updating feature settings

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'decouple')*

------
https://chatgpt.com/codex/tasks/task_e_683fbba2a0fc832abb092e1ad01202b1