### PR TITLE
Update axios baseURL and document server ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,15 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
-First, run the development server:
+First, run the development servers.
+
+Start the Django backend:
+
+```bash
+python manage.py runserver 8000
+```
+
+Then, in another terminal, launch the Next.js app:
 
 ```bash
 npm run dev
@@ -14,7 +22,8 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+The Next.js server runs on [http://localhost:3001](http://localhost:3001) by default and expects the Django API at [http://localhost:8000/api](http://localhost:8000/api).
+Open [http://localhost:3001](http://localhost:3001) with your browser to see the result.
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 

--- a/src/api_request/axios.ts
+++ b/src/api_request/axios.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import secureLocalStorage from 'react-secure-storage';
 const base = axios.create({
-	//  baseURL: "https://home.moodsinger.com/api",
-	baseURL: 'http://localhost:3000/api',
-	// baseURL: "https://api.home.moodsinger.com/api"
+        //  baseURL: "https://home.moodsinger.com/api",
+        baseURL: 'http://localhost:8000/api',
+        // baseURL: "https://api.home.moodsinger.com/api"
 });
 
 // Request interceptor


### PR DESCRIPTION
## Summary
- point axios client to Django API on port 8000
- update README with instructions for running the Django and Next.js servers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fbc94f1bc832a958a701653788578