### PR TITLE
Fix duplicate shebang in manage.py

### DIFF
--- a/manage.py
+++ b/manage.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
-#!/usr/bin/env python
 import os
 import sys
 


### PR DESCRIPTION
## Summary
- remove an extra shebang line in `manage.py`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run lint` *(fails: interactive setup prompt)*
- `python manage.py check` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_683fc2a9d16c832abe1143a16c7046c6